### PR TITLE
Add support for config.ini file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ target/
 #Ipython Notebook
 .ipynb_checkpoints
 *.ipynb
+
+#J-Kernel Configuration
+config.ini

--- a/config-sample.ini
+++ b/config-sample.ini
@@ -1,0 +1,10 @@
+[jpath]
+
+# J binary directory (the one with all the binaries)
+# bin_path = C:\j64-804\bin
+bin_path = ~/j64-804/bin
+
+# Viewmat creates a temporary picture file in order to display it.
+# This is the path the kernel will use to find it.
+# viewmat_image_location = C:\j64-804\temp\viewmat.png
+viewmat_image_location = ~/j64-804-user/temp/viewmat.png

--- a/jkernel.py
+++ b/jkernel.py
@@ -7,10 +7,22 @@ import os
 
 from wrapper import JWrapper
 
-# CUSTOMIZE HERE
-# Viewmat creates a temporary picture file in order to display it.
-# This is the path the kernel will use to find it.
-j_viewmat_image_location = "~/j64-804-user/temp/viewmat.png"
+# Py2
+# import ConfigParser
+
+# config = ConfigParser.RawConfigParser()
+# config.read('config.ini')
+# j_viewmat_image_location = config.get('jpath', 'viewmat_image_location')
+
+# Py3
+import configparser
+
+config = configparser.ConfigParser()
+if not config.read('config.ini'):
+    config['jpath'] = {'bin_path': '~/j64-804/bin', 'viewmat_image_location': '~/j64-804-user/temp/viewmat.png'}
+    with open('config.ini', 'w') as configfile:
+        config.write(configfile)
+j_viewmat_image_location = config['jpath']['viewmat_image_location']
 
 class JKernel(Kernel):
     implementation = 'jkernel'

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ![](http://i.imgur.com/wL5ZTfu.png)
 
-To install: place the files in ~/.ipython/kernels/jkernel* directory. Make sure that the paths to J at the top of wrapper.py and jkernel.py are correct. For those unfamiliar with Python, the file path on Windows needs backslashes escaped; for example: `"C:\\Program Files\\j64-804\\bin"`. Open `jupyter notebook` (or `ipython notebook`, but it's deprecated) from this directory.
+To install: place the files in ~/.ipython/kernels/jkernel* directory. Rename "config-sample.ini" to "config.ini" and change the paths to match your setup. Open `jupyter notebook` (or `ipython notebook`, but it's deprecated) from this directory.
 
 (* or the newer location: `~/.local/share/jupyter/kernels/jkernel` on Linux, `%APPDATA%\jupyter\kernels\jkernel` on Windows, `~/Library/Jupyter/kernels/jkernel` on OSX.)
 

--- a/wrapper.py
+++ b/wrapper.py
@@ -5,9 +5,22 @@ from ctypes import *
 import sys
 import os
 
-# CUSTOMIZE HERE
-# J binary directory (the one with all the binaries)
-j_bin_path = os.path.expanduser("~/j64-804/bin")
+# Py2
+# import ConfigParser
+
+# config = ConfigParser.RawConfigParser()
+# config.read('config.ini')
+# j_bin_path = os.path.expanduser(config.get('jpath', 'bin_path'))
+
+# Py3
+import configparser
+
+config = configparser.ConfigParser()
+if not config.read('config.ini'):
+    config['jpath'] = {'bin_path': '~/j64-804/bin', 'viewmat_image_location': '~/j64-804-user/temp/viewmat.png'}
+    with open('config.ini', 'w') as configfile:
+        config.write(configfile)
+j_bin_path = os.path.expanduser(config['jpath']['bin_path'])
 
 def get_libj(binpath):
     if os.name == "nt":


### PR DESCRIPTION
Users should rename "config-sample.ini" to "config.ini". Git now ignores
config.ini and thus won't overwrite it.
